### PR TITLE
Hot fix allow package to run

### DIFF
--- a/plydata/eval.py
+++ b/plydata/eval.py
@@ -14,8 +14,9 @@ def _all_future_flags():
     flags = 0
     for feature_name in __future__.all_feature_names:
         feature = getattr(__future__, feature_name)
-        if feature.getMandatoryRelease() > sys.version_info:
-            flags |= feature.compiler_flag
+        if feature.getMandatoryRelease() is not None:
+            if feature.getMandatoryRelease() > sys.version_info:
+                flags |= feature.compiler_flag
     return flags
 
 


### PR DESCRIPTION
Closes #33 

Greetings, 
I love this package and would like to see this work for Python 3.11. Due to a recent change, one gets this error:

```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/greenelabnlp/Documents/GitHub/plydata/plydata/__init__.py", line 1, in <module>
    from .one_table_verbs import *  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/greenelabnlp/Documents/GitHub/plydata/plydata/one_table_verbs.py", line 6, in <module>
    from .operators import DataOperator
  File "/Users/greenelabnlp/Documents/GitHub/plydata/plydata/operators.py", line 6, in <module>
    from .eval import EvalEnvironment
  File "/Users/greenelabnlp/Documents/GitHub/plydata/plydata/eval.py", line 22, in <module>
    _ALL_FUTURE_FLAGS = _all_future_flags()
                        ^^^^^^^^^^^^^^^^^^^
  File "/Users/greenelabnlp/Documents/GitHub/plydata/plydata/eval.py", line 17, in _all_future_flags
    if feature.getMandatoryRelease() > sys.version_info:
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: '>' not supported between instances of 'NoneType' and 'sys.version_info'
```

Upon reading this error. I guess that `feature.getMandatoryRelease()` returns a None value, so I made a quick fix to check for that. Have confirmed the package can be loaded after my fix on Python 3.11.